### PR TITLE
Add constants for better control of HTTP2 push

### DIFF
--- a/src/WordPress/HTTP2ServerPush.php
+++ b/src/WordPress/HTTP2ServerPush.php
@@ -1,67 +1,59 @@
 <?php
-
 // TODO: 
 // Get rid of $GLOBALS and use static variables
 // Make class functions non-static
 // Add debug logs. Need dependency injection of logger to this class
 namespace CF\WordPress;
-
 class HTTP2ServerPush
 {
     private static $initiated = false;
-
     public static function init()
     {
         if (!self::$initiated) {
             self::initHooks();
         }
-
         ob_start();
     }
-
     public static function initHooks()
     {
         self::$initiated = true;
-
         add_action('wp_head', array('\CF\WordPress\HTTP2ServerPush', 'http2ResourceHints'), 99, 1);
         add_filter('script_loader_src', array('\CF\WordPress\HTTP2ServerPush', 'http2LinkPreloadHeader'), 99, 1);
         add_filter('style_loader_src', array('\CF\WordPress\HTTP2ServerPush', 'http2LinkPreloadHeader'), 99, 1);
     }
-
     public static function http2LinkPreloadHeader($src)
     {
         if (strpos($src, home_url()) !== false) {
             $preload_src = apply_filters('http2_link_preload_src', $src);
-
             if (!empty($preload_src)) {
                 $newHeader = sprintf(
                     'Link: <%s>; rel=preload; as=%s',
                     esc_url(self::http2LinkUrlToRelativePath($preload_src)),
                     sanitize_html_class(self::http2LinkResourceHintAs(current_filter()))
                 );
-
+                $maxHeaderSize = 3072;
+                if(defined('CLOUDFLARE_HTTP2_SERVER_PUSH_HEADER_SIZE')) {
+                  $maxHeaderSize = absint(CLOUDFLARE_HTTP2_SERVER_PUSH_HEADER_SIZE);
+                };
                 // If the current header size is larger than 3KB (3072 bytes)
                 // ignore following resources which can be pushed
                 // This is a workaround for Cloudflare's 8KB header limit
                 // and fastcgi default 4KB header limit
                 $headerAsString = implode('  ', headers_list());
-
                 // +2 comes from the last CRLF since it's two bytes
                 $headerSize = strlen($headerAsString) + strlen($newHeader) + 2;
                 if ($headerSize > 3072) {
-                    error_log('Cannot Server Push (header size over 3072 Bytes).');
+                    if(defined('CLOUDFLARE_HTTP2_SERVER_PUSH_LOG')) {
+                      error_log('Cannot Server Push (header size over 3072 Bytes).');
+                    }
                     return $src;
                 }
-
                 header($newHeader, false);
-
                 $GLOBALS['http2_'.self::http2LinkResourceHintAs(current_filter()).'_srcs'][] = self::http2LinkUrlToRelativePath($preload_src);
             }
         }
-
         return $src;
     }
-
     /**
      * Render "resource hints" in the <head> section of the page. These encourage preload/prefetch behavior
      * when HTTP/2 support is lacking.
@@ -77,7 +69,6 @@ class HTTP2ServerPush
             }
         });
     }
-
     /**
      * Convert an URL with authority to a relative path.
      *
@@ -89,7 +80,6 @@ class HTTP2ServerPush
     {
         return '//' === substr($src, 0, 2) ? preg_replace('/^\/\/([^\/]*)\//', '/', $src) : preg_replace('/^http(s)?:\/\/[^\/]*/', '', $src);
     }
-
     /**
      * Maps a WordPress hook to an "as" parameter in a resource hint.
      *


### PR DESCRIPTION
Added two constants to control HTTP2 server push behavior:

`CLOUDFLARE_HTTP2_SERVER_PUSH_HEADER_SIZE` - allows setting the max header size you can push. Useful for those (like me) that know exactly what fastcgi can push through.
`CLOUDFLARE_HTTP2_SERVER_PUSH_LOG` - setting this will _enable_ the somewhat... shall we say spammy... `error_log` whenever a file is over the max header size